### PR TITLE
fix: update error in the tic-tac-toe update logic

### DIFF
--- a/src/rogue.behavior.js
+++ b/src/rogue.behavior.js
@@ -59,6 +59,8 @@ export default System.be({
       }
 
       return [
+        { Disassociate: [self, 'playerX', playerX] },
+        { Disassociate: [self, 'playerY', playerY] },
         { Associate: [self, 'playerX', newX] },
         { Associate: [self, 'playerY', newY] },
       ]


### PR DESCRIPTION
There was a little error in the logic, possible caused by unintuitive choices made by database. Specifically when you assert a fact it does not retract previous one even if the [entity, attribute] pair is the same. That is intentionally so because it models all relations as 1:many and never 1:1. Which in turn because schema changes from 1:1 to 1:n tends to be painful and if you just assume 1:n you can avoid that pain down the line.

In other words if you want cardinality 1 you just need to always retract previous fact and assert new fact 😅 Perhaps we'll introduce something like `Swap` in the future for convenience, but right now it's up to the program to retract facts that are no longer true.

P.S.: Sorry for the large delta it's just my editor passes through prettier and I was lazy to undo it.